### PR TITLE
Feature fetch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.dll
 *.so
 *.dylib
+cmd/
 
 # Test binary, built with `go test -c`
 *.test

--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@
 *.dll
 *.so
 *.dylib
-cmd/
 
 # Test binary, built with `go test -c`
 *.test
@@ -20,3 +19,7 @@ cmd/
 
 # Go workspace file
 go.work
+
+# custom
+cmd/
+.env

--- a/constraint.go
+++ b/constraint.go
@@ -1,0 +1,17 @@
+package gobubble
+
+type (
+	ConstraintType string
+
+	Constraint struct {
+		Key            string         `json:"key"`
+		ConstraintType ConstraintType `json:"constraint_type"`
+		Value          interface{}    `json:"value"`
+	}
+)
+
+const (
+	Equal    ConstraintType = "equals"
+	NotEqual ConstraintType = "not equal"
+	In       ConstraintType = "in"
+)

--- a/fetch.go
+++ b/fetch.go
@@ -1,0 +1,103 @@
+package gobubble
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+)
+
+type (
+	Constraint struct {
+		Key            string      `json:"key"`
+		ConstraintType string      `json:"constraint_type"`
+		Value          interface{} `json:"value"`
+	}
+
+	Request struct {
+		URL         string
+		Token       string
+		Target      string
+		Constraints []Constraint
+	}
+
+	payload struct {
+		Response struct {
+			Results   json.RawMessage `json:"results"`
+			Count     int             `json:"count"`
+			Remaining int             `json:"remaining"`
+		} `json:"response"`
+	}
+)
+
+func NewConstraint(key string, constraintType string, value interface{}) *Constraint {
+	return &Constraint{
+		Key:            key,
+		ConstraintType: constraintType,
+		Value:          value,
+	}
+}
+
+// func NewRequest(url string, token string, target string) *Request {
+// 	return &Request{
+// 		url:    url,
+// 		token:  token,
+// 		target: target,
+// 	}
+// }
+
+func Fetch(req Request) error {
+	u, err := url.Parse(req.URL)
+	if err != nil {
+		return fmt.Errorf("invalid url: %w", err)
+	}
+	u.Path = path.Join(u.Path, "api/1.1/obj", req.Target)
+
+	qcs, err := json.Marshal(req.Constraints)
+	if err != nil {
+		return fmt.Errorf("json.Marshal: %w", err)
+	}
+
+	q := u.Query()
+	q.Set("constraints", string(qcs))
+	// q.Set("cursor", strconv.Itoa(cursor))
+	u.RawQuery = q.Encode()
+
+	r, err := http.NewRequest(http.MethodGet, u.String(), nil)
+	if err != nil {
+		return fmt.Errorf("http.NewRequest: %w", err)
+	}
+	r.Header.Add("Authorization", "Bearer"+" "+req.Token)
+
+  fmt.Printf("req: %+v", r)
+
+	res, err := http.DefaultClient.Do(r)
+	if err != nil {
+		return fmt.Errorf("http.Get: %w", err)
+	}
+	defer func() {
+		err := res.Body.Close()
+		if err != nil {
+			// TODO
+			fmt.Println(err)
+		}
+	}()
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return fmt.Errorf("io.ReadAll: %w", err)
+	}
+  var p payload
+  if err := json.Unmarshal(body, &p); err != nil {
+    return fmt.Errorf("json.Unmarshal: %w", err)
+  }
+  fmt.Println(p.Response)
+
+	return nil
+}
+
+func SampleGenerics[T any](a, b T) []T {
+	return []T{a, b}
+}

--- a/fetch.go
+++ b/fetch.go
@@ -13,12 +13,6 @@ import (
 const FetchLimitMax = 100
 
 type (
-	Constraint struct {
-		Key            string      `json:"key"`
-		ConstraintType string      `json:"constraint_type"`
-		Value          interface{} `json:"value"`
-	}
-
 	FetchRequest struct {
 		URL         string
 		Token       string

--- a/fetch.go
+++ b/fetch.go
@@ -88,9 +88,9 @@ func fetch[T any](fetchRequest FetchRequest, cursor int) (parsedResponse *parsed
 	if err != nil {
 		return nil, fmt.Errorf("http.Get: %w", err)
 	}
-  if rawResponse.StatusCode != http.StatusOK {
-    return nil, fmt.Errorf("unexpected status: %d", rawResponse.StatusCode)
-  }
+	if rawResponse.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status: %d", rawResponse.StatusCode)
+	}
 	defer func() {
 		if cerr := rawResponse.Body.Close(); cerr != nil {
 			err = fmt.Errorf("original: %w, close: %w", err, cerr)

--- a/fetch.go
+++ b/fetch.go
@@ -84,7 +84,7 @@ func parseResponse[T any](res *http.Response) (*parsedResponse[T], error) {
 	}, nil
 }
 
-func fetch[T any](fetchRequest FetchRequest, cursor int) (*parsedResponse[T], error) {
+func fetch[T any](fetchRequest FetchRequest, cursor int) (parsedResponse *parsedResponse[T], err error) {
 	httpReq, err := newHttpRequest(fetchRequest, cursor)
 	if err != nil {
 		return nil, fmt.Errorf("generateRequest: %w", err)
@@ -95,19 +95,17 @@ func fetch[T any](fetchRequest FetchRequest, cursor int) (*parsedResponse[T], er
 		return nil, fmt.Errorf("http.Get: %w", err)
 	}
 	defer func() {
-		err := rawResponse.Body.Close()
-		if err != nil {
-			// TODO
-			fmt.Println(err)
-		}
+		if cerr := rawResponse.Body.Close(); cerr != nil {
+      err = fmt.Errorf("original: %w, close: %w", err, cerr)
+    }
 	}()
 
-	parsedResponse, err := parseResponse[T](rawResponse)
+	parsedResponse, err = parseResponse[T](rawResponse)
 	if err != nil {
 		return nil, fmt.Errorf("parseResponse: %w", err)
 	}
 
-	return parsedResponse, nil
+	return
 }
 
 func Fetch[T any](req FetchRequest) ([]T, error) {

--- a/fetch.go
+++ b/fetch.go
@@ -82,7 +82,3 @@ func Fetch[T any](req Request) ([]T, error) {
 
 	return dest, nil
 }
-
-func SampleGenerics[T any](a, b T) []T {
-	return []T{a, b}
-}

--- a/fetch.go
+++ b/fetch.go
@@ -96,8 +96,8 @@ func fetch[T any](fetchRequest FetchRequest, cursor int) (parsedResponse *parsed
 	}
 	defer func() {
 		if cerr := rawResponse.Body.Close(); cerr != nil {
-      err = fmt.Errorf("original: %w, close: %w", err, cerr)
-    }
+			err = fmt.Errorf("original: %w, close: %w", err, cerr)
+		}
 	}()
 
 	parsedResponse, err = parseResponse[T](rawResponse)

--- a/fetch.go
+++ b/fetch.go
@@ -88,6 +88,9 @@ func fetch[T any](fetchRequest FetchRequest, cursor int) (parsedResponse *parsed
 	if err != nil {
 		return nil, fmt.Errorf("http.Get: %w", err)
 	}
+  if rawResponse.StatusCode != http.StatusOK {
+    return nil, fmt.Errorf("unexpected status: %d", rawResponse.StatusCode)
+  }
 	defer func() {
 		if cerr := rawResponse.Body.Close(); cerr != nil {
 			err = fmt.Errorf("original: %w, close: %w", err, cerr)


### PR DESCRIPTION
https://github.com/temp-LLC/go-bubble/issues/1

## 変更点
- teeeのdaoをジェネリクスを使って書き換え
- https://github.com/temp-LLC/teee/blob/main/backend/bubble/dao/dating.go とhttps://github.com/temp-LLC/teee/blob/main/backend/bubble/get.go あたりを参考に作りました。
- `BubbleClient`型みたいなのを作ろうとしたのですが、メソッドではジェネリクス使えないぽいです。

## 動作確認
こんな感じでデータ取得しました。
```go
	token := os.Getenv("BUBBLE_API_KEY")

	ret, err := gobubble.Fetch[Dating](
		gobubble.FetchRequest{
			URL:         "https://teee.me/version-test/",
			Token:       token,
			Target:      "Dating",
			Constraints: []gobubble.Constraint{},
		},
	)
	if err != nil {
		panic(err)
	}

	fmt.Println("fetched count:", len(ret))
```

確認したこと
- 100以上のデータ取得
  - cursorの動作確認
- constraintの動作確認
